### PR TITLE
 Fix description for analyzing your own system

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ LaTeX distribution.
 
 ## Analyzing your own system
 
-If you don't care about other systems, you can also just run `python annotate_coco.py`
-and then run `python analyze_my_system.py descriptions.json`. This will generate all statistics for a single system.
-Make sure your system output is in the standard JSON format. See the Systems folder for examples.
-
 If you don't care about other systems, you can also just run the following commands (assuming you stored your system output in `descriptions.json`).
 
 * `python annotate_coco.py`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Make sure your system output is in the standard JSON format. See the Systems fol
 If you don't care about other systems, you can also just run the following commands (assuming you stored your system output in `descriptions.json`).
 
 * `python annotate_coco.py`
+* `python coco_stats.py`
 * `python analyze_my_system.py descriptions.json`
 
 This will first generate the basis statistics for MS COCO (the standard of comparison), and then generate all statistics for a single system. Make sure your system output is in the standard JSON format. See the Systems folder for examples.


### PR DESCRIPTION
Before calling `python analyze_my_system.py descriptions.json`, one
needs to call `python coco_stats.py` because the `train_stats.json` and
`val_stats.json` for the COCO dataset are needed to calculate the global
recall.